### PR TITLE
feat: add SARIF export support via emitSarif for machine readable diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,25 @@ const diagnostics = [_]Diagnostic{ diag1, diag2, diag3 };
 reporter.reportMany(&diagnostics);
 ```
 
+#### `emitSarif`
+
+Exports diagnostics to SARIF format (version 2.1.0) as a JSON stream.
+
+```zig
+try emitSarif(diagnostics, writer);
+```
+
+Writes a `runs` array with all diagnostics as SARIF `results`. If a `code` is set, it's included as a rule ID.
+
+```zig
+const file = try std.fs.cwd().createFile("report.sarif.json", .{});
+defer file.close();
+
+try emitSarif(&[_]Diagnostic{diag}, file.writer());
+```
+
+Use this to integrate with editors or CI tools that support SARIF (e.g. GitHub, VS Code, etc).
+
 ### Convenience Functions
 
 #### `createDiagnostic`

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,3 +1,11 @@
+//! Fehler is a diagnostic reporting library for Zig.
+//!
+//! It provides rich, colorful compiler-style diagnostics with support for:
+//! - Source ranges and highlighting
+//! - Multiple output formats (`fehler`, `gcc`, `msvc`)
+//! - Fluent diagnostic construction
+//! - SARIF JSON export for CI/editor integration
+
 const std = @import("std");
 const print = std.debug.print;
 const json = std.json;


### PR DESCRIPTION
this PR introduces SARIF JSON export support to the fehler error reporting system.

### What's Changed

* adds `emitSarif` function for exporting diagnostics in SARIF 2.1.0 JSON format
* writes SARIF output to any `std.io.Writer` for flexible integration
* includes rule ID, message, and precise location for each diagnostic
* adds tests verifying SARIF output structure and contents
* updates README with SARIF API usage and examples
* adds top-level module doc comment describing fehler library and usage

### Non-Breaking Change

existing error reporting behavior remains unchanged. SARIF export is opt-in and does not affect terminal output or other formats.