### PR TITLE
chore: upgrade project to Zig 0.15.1

### DIFF
--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.14.1
+          version: 0.15.1
 
       - name: "Run the tests."
         run: zig test src/tests.zig

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ reporter.reportMany(&diagnostics);
 Exports diagnostics to SARIF format (version 2.1.0) as a JSON stream.
 
 ```zig
-try emitSarif(allocator, capacity, diagnostics, writer);
+try emitSarif(allocator, diagnostics, writer);
 ```
 
 Writes a `runs` array with all diagnostics as SARIF `results`. If a `code` is set, it's included as a rule ID.
@@ -233,7 +233,7 @@ Writes a `runs` array with all diagnostics as SARIF `results`. If a `code` is se
 const file = try std.fs.cwd().createFile("report.sarif.json", .{});
 defer file.close();
 
-try emitSarif(std.heap.page_allocator, 256, &[_]Diagnostic{diag}, file.writer());
+try emitSarif(std.heap.page_allocator, &[_]Diagnostic{diag}, file.writer());
 ```
 
 Use this to integrate with editors or CI tools that support SARIF (e.g. GitHub, VS Code, etc).

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ reporter.reportMany(&diagnostics);
 Exports diagnostics to SARIF format (version 2.1.0) as a JSON stream.
 
 ```zig
-try emitSarif(diagnostics, writer);
+try emitSarif(allocator, capacity, diagnostics, writer);
 ```
 
 Writes a `runs` array with all diagnostics as SARIF `results`. If a `code` is set, it's included as a rule ID.
@@ -233,7 +233,7 @@ Writes a `runs` array with all diagnostics as SARIF `results`. If a `code` is se
 const file = try std.fs.cwd().createFile("report.sarif.json", .{});
 defer file.close();
 
-try emitSarif(&[_]Diagnostic{diag}, file.writer());
+try emitSarif(std.heap.page_allocator, 256, &[_]Diagnostic{diag}, file.writer());
 ```
 
 Use this to integrate with editors or CI tools that support SARIF (e.g. GitHub, VS Code, etc).

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .fehler,
     .version = "0.5.1",
     .fingerprint = 0x2763d78399d579f0,
-    .minimum_zig_version = "0.14.1",
+    .minimum_zig_version = "0.15.1",
     .dependencies = .{},
     .paths = .{
         "build.zig",

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -186,12 +186,7 @@ test "emitSarif outputs valid JSON with basic diagnostic" {
         .withCode("E001");
 
     var stream = std.io.Writer.fixed(&buffer);
-    try felher.emitSarif(
-        std.heap.page_allocator,
-        256,
-        &[_]Diagnostic{ diag1, diag2 },
-        &stream,
-    );
+    try felher.emitSarif(std.heap.page_allocator, &[_]Diagnostic{ diag1, diag2 }, &stream);
 
     const json = buffer[0..stream.end];
     try testing.expect(std.mem.indexOf(u8, json, "\"message\"") != null);

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -185,10 +185,15 @@ test "emitSarif outputs valid JSON with basic diagnostic" {
         .withLocation("main.zig", 3, 4)
         .withCode("E001");
 
-    var stream = std.io.fixedBufferStream(&buffer);
-    try felher.emitSarif(&[_]Diagnostic{ diag1, diag2 }, stream.writer());
+    var stream = std.io.Writer.fixed(&buffer);
+    try felher.emitSarif(
+        std.heap.page_allocator,
+        256,
+        &[_]Diagnostic{ diag1, diag2 },
+        &stream,
+    );
 
-    const json = buffer[0..stream.pos];
+    const json = buffer[0..stream.end];
     try testing.expect(std.mem.indexOf(u8, json, "\"message\"") != null);
     try testing.expect(std.mem.indexOf(u8, json, "invalid token") != null);
     try testing.expect(std.mem.indexOf(u8, json, "main.zig") != null);


### PR DESCRIPTION
this PR upgrades the project to Zig 0.15.1, updating code, tests, CI, and documentation to match the latest language changes.

### What's Changed

* updates `src/root.zig` to use the new writer and allocator APIs
* updates `src/test.zig` to reflect allocator and ArrayList changes
* bumps `minimum_zig_version` in `build.zig.zon` to `0.15.1`
* updates GitHub Actions CI workflow to install Zig 0.15.1
* updates `README` documentation to reference Zig 0.15.1

### Breaking Change

`emitSarif` now requires an allocator argument. Any code calling `emitSarif` must be updated to pass an allocator.
